### PR TITLE
[Github Action] Fix build-and-push-rag-content job

### DIFF
--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: sigstore/cosign-installer@v3.8.1
 
       - name: Build only partial rag-content when running in the check pipeline
-        if: github.event_name != 'schedule' && github.event_name != 'push'
+        if: github.event_name == 'pull_request'
         run: |
           echo OS_PROJECTS="nova" >> $GITHUB_ENV
 

--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -23,7 +23,6 @@ env:
 
 jobs:
   build-and-push-rag-content:
-    environment: trusted
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space (Ubuntu)

--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -38,13 +38,6 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.8.1
 
-      - name: Log in to registry.redhat.io
-        uses: redhat-actions/podman-login@v1
-        with:
-          username: ${{ secrets.REDHAT_REGISTRY_LOGIN }}
-          password: ${{ secrets.REDHAT_REGISTRY_PASSWORD }}
-          registry: registry.redhat.io
-
       - name: Build only partial rag-content when running in the check pipeline
         if: github.event_name != 'schedule' && github.event_name != 'push'
         run: |

--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -46,7 +46,7 @@ jobs:
           registry: registry.redhat.io
 
       - name: Build only partial rag-content when running in the check pipeline
-        if: github.event_name != 'schedule' || github.event_name != 'push'
+        if: github.event_name != 'schedule' && github.event_name != 'push'
         run: |
           echo OS_PROJECTS="nova" >> $GITHUB_ENV
 

--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build-and-push-rag-content:
+    environment: trusted
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space (Ubuntu)


### PR DESCRIPTION
* It seems like we do not need to be logged in to registry.redhat.io 
in order to be able to pull the ubi9/ubi-minimal:latest image.

* Currently, we execute the partial image build when event_name is
not 'push' OR 'schedule' when we should be building a partial image
build if event_name is not 'push' AND 'schedule'.