### PR TITLE
[Github Action] Change pull_request to pull_request_target

### DIFF
--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:
@@ -33,7 +33,14 @@ jobs:
           tool-cache: true
 
       - name: Checkout to the repository
+        if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v4
+
+      - name: Checkout pull request code (pull_request_target)
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.8.1


### PR DESCRIPTION
We need to change the pull_request trigger to pull_request_target in order to be able to access the repository secrets when PR is proposed. By default pull_request does not have access to the secrets and this behavior is not modifiable (due to security reasons).

The pull_request_target trigger has access to the secrets but runs the job against the target branch.

We checkout the code from the PR in the job which might be a security concern but we also use a setting for this repository which allows execution of workflows only for members of the openstack-lightspeed org (approval required for outsiders).