### PR TITLE
Extend vector db with services present in RHOSO

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -11,6 +11,9 @@ WORKDIR /workdir
 
 COPY ./scripts/get_openstack_plaintext_docs.sh ./
 COPY ./scripts/generate_embeddings_openstack.py ./
+
+# Graphviz is needed to generate text documentation for octavia
+RUN dnf install -y graphviz
 RUN pip install tox
 RUN ./get_openstack_plaintext_docs.sh
 

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -12,7 +12,7 @@ OS_VERSION=${OS_VERSION:-2024.2}
 
 # List of OpenStack Projects
 _OS_PROJECTS="nova horizon keystone neutron cinder manila glance swift ceilometer \
-octavia designate heat placement ironic barbican aodh"
+octavia designate heat placement ironic barbican aodh watcher"
 OS_PROJECTS=${OS_PROJECTS:-$_OS_PROJECTS}
 # Read the environment variable into an array
 IFS=' ' read -r -a os_projects <<< "$OS_PROJECTS"


### PR DESCRIPTION
This commit extends the default set of projects we use to build the vector database. The default value was modified to include services available in RHOSO environment.