### PR TITLE
Add more OpenStack projects

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -11,7 +11,8 @@ COPY ./scripts/get_openstack_plaintext_docs.sh ./
 COPY ./scripts/generate_embeddings_openstack.py ./
 
 # Graphviz is needed to generate text documentation for octavia
-RUN dnf install -y graphviz
+# python-devel and pcre-devel are needed for python-openstackclient
+RUN dnf install -y graphviz python-devel pcre-devel
 RUN pip install tox
 RUN ./get_openstack_plaintext_docs.sh
 

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -25,9 +25,13 @@ fi
 # OpenStack Version
 OS_VERSION=${OS_VERSION:-2024.2}
 
+# TODO(lucasagomes): Look into adding the "tacker" project. Document generation
+# for this project gets stuck in an infinite loop
 # List of OpenStack Projects
 _OS_PROJECTS="nova horizon keystone neutron cinder manila glance swift ceilometer \
-octavia designate heat placement ironic barbican aodh watcher"
+octavia designate heat placement ironic barbican aodh watcher adjutant blazar \
+cloudkitty cyborg magnum mistral skyline-apiserver skyline-console storlets \
+venus vitrage zun python-openstackclient tempest trove zaqar masakari"
 OS_PROJECTS=${OS_PROJECTS:-$_OS_PROJECTS}
 
 # Read the environment variable into an array
@@ -73,16 +77,17 @@ log_and_die() {
 #   generate_text_doc "nova"
 generate_text_doc() {
     local project=$1
+    local _os_version=$2
     local tox_text_docs_target="
 
 [testenv:text-docs]
 description =
     Build documentation in text format.
-deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$OS_VERSION}
-  -r{toxinidir}/doc/requirements.txt
 commands =
   sphinx-build --keep-going -j auto -b text doc/source doc/build/text
+deps =
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version}
+  -r{toxinidir}/doc/requirements.txt
 "
 
     echo "Generating the plain-text documentation for OpenStack $project"
@@ -92,26 +97,34 @@ commands =
     fi
 
     cd "$project"
-    git switch stable/"$OS_VERSION"
-    git pull origin stable/"$OS_VERSION"
+    if [ "$_os_version" != "master" ]; then
+        git switch stable/"$_os_version"
+        git pull origin stable/"$_os_version"
+    fi
 
     # TODO(lpiwowar): Remove workarounds. Some of the documentations do not work with
     # the feature of sphinx-build that allows generation of the docs in text format.
     # List of issues:
-    #    * designate = with custom ext.support_matrix extension the generation of the
-    #                  documentation gets stuck in infinite loop
+    #    * designate   = with custom ext.support_matrix extension the generation of the
+    #                    documentation gets stuck in infinite loop
     #
-    #    * ironic    = with sphinxcontrib.apidoc extension the generation of the
-    #                  documentation gets stuck in infinite loop
+    #    * ironic      = with sphinxcontrib.apidoc extension the generation of the
+    #                    documentation gets stuck in infinite loop
     #
-    #    * heat      = AttributeError: 'TextTranslator' object has no attribute '_classifier_count_in_li'
-    #                  when doc/source/template_guide documentation is present
+    #    * heat        = AttributeError: 'TextTranslator' object has no attribute '_classifier_count_in_li'
+    #                    when doc/source/template_guide documentation is present
+    #
+    #    * trove/zaqar = The doc/requirements.txt file does not install all deps required to
+    #                    generate the docs
+    #
     if [ "$project" == "designate" ]; then
         sed -i "/'ext\.support_matrix',/d" "doc/source/conf.py"
     elif [ "$project" == "ironic" ]; then
         sed -i "/'sphinxcontrib\.apidoc',/d" "doc/source/conf.py"
     elif [ "$project" == "heat" ]; then
         rm -rf doc/source/template_guide/
+    elif [[ "$project" == "trove" || "$project" == "zaqar" ]]; then
+        tox_text_docs_target+="  -r{toxinidir}/requirements.txt"
     fi
 
     if grep -q "text-docs" tox.ini; then
@@ -147,7 +160,12 @@ for os_project in "${os_projects[@]}"; do
     LOG_FILES+=("${os_project_log_file}")
 
     echo "Generating documentation for ${os_project}. [logs -> ${WORKING_DIR}/${os_project_log_file}]"
-    generate_text_doc "$os_project" > "${os_project_log_file}" 2>&1 &
+    _os_version=$OS_VERSION
+    # The tempest project is branchless
+    if [ "${os_project}" == "tempest" ]; then
+        _os_version="master"
+    fi
+    generate_text_doc "$os_project" "$_os_version" > "${os_project_log_file}" 2>&1 &
 
     num_running_subproc=$(jobs -r | wc -l)
     if [ "${num_running_subproc}" -gt "${NUM_WORKERS}" ]; then


### PR DESCRIPTION
This commit adds more OpenStack projects to the list of documentation for the OpenStack RAG.

The added projects are: adjutant blazar cloudkitty cyborg magnum masakari mistral skyline-apiserver skyline-console storlets trove venus vitrage zaqar zun tempest python-openstackclient.
