### PR TITLE
Remove cloudkitty

### DIFF
--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -30,7 +30,7 @@ OS_VERSION=${OS_VERSION:-2024.2}
 # List of OpenStack Projects
 _OS_PROJECTS="nova horizon keystone neutron cinder manila glance swift ceilometer \
 octavia designate heat placement ironic barbican aodh watcher adjutant blazar \
-cloudkitty cyborg magnum mistral skyline-apiserver skyline-console storlets \
+cyborg magnum mistral skyline-apiserver skyline-console storlets \
 venus vitrage zun python-openstackclient tempest trove zaqar masakari"
 OS_PROJECTS=${OS_PROJECTS:-$_OS_PROJECTS}
 


### PR DESCRIPTION
The processing of the cloudkitty documentation is linked to this issue (NotImplementedException raised) [1]. This issue blocks the periodic builds of the image. Let's remove it for now.

[1] https://github.com/openstack-lightspeed/rag-content/issues/17