### PR TITLE
Process doc-* directories in rhoso docs

### DIFF
--- a/scripts/get_rhoso_plaintext_docs.sh
+++ b/scripts/get_rhoso_plaintext_docs.sh
@@ -37,11 +37,12 @@ generate_text_docs_rhoso() {
     # TODO(lpiwowar): Remove -k (skips validation of the certificate)
     curl -L -k -o "${attributes_file}" "${RHOSO_DOCS_ATTRIBUTES_FILE_URL}"
 
-    # TODO(lpiwowar): Process other folders than "titles"
-    python ./scripts/rhoso_adoc_docs_to_text.py \
-        --input-dir ${rhoso_docs_folder}/titles \
-        --attributes-file ${attributes_file} \
-        --output-dir openstack-docs-plaintext/
+    for subdir in "${rhoso_docs_folder}/titles" "${rhoso_docs_folder}"/doc-*; do
+        python ./scripts/rhoso_adoc_docs_to_text.py \
+            --input-dir "${subdir}" \
+            --attributes-file "${attributes_file}" \
+            --output-dir rhoso-docs-plaintext/
+    done
 }
 
 generate_text_docs_rhoso

--- a/scripts/get_rhoso_plaintext_docs.sh
+++ b/scripts/get_rhoso_plaintext_docs.sh
@@ -41,7 +41,7 @@ generate_text_docs_rhoso() {
         python ./scripts/rhoso_adoc_docs_to_text.py \
             --input-dir "${subdir}" \
             --attributes-file "${attributes_file}" \
-            --output-dir rhoso-docs-plaintext/
+            --output-dir openstack-docs-plaintext/
     done
 }
 

--- a/scripts/rhoso_adoc_docs_to_text.py
+++ b/scripts/rhoso_adoc_docs_to_text.py
@@ -116,7 +116,7 @@ def red_hat_docs_path(
                 continue
 
             if (path_title := get_xml_element_text(tree, "title")) is None:
-                LOG.warning(f"{docinfo} title is blanks Skipping ...")
+                LOG.warning(f"{docinfo} title is blank. Skipping ...")
                 continue
 
             path_title = path_title.lower().replace(" ", "_")

--- a/scripts/rhoso_adoc_docs_to_text.py
+++ b/scripts/rhoso_adoc_docs_to_text.py
@@ -19,6 +19,7 @@ import argparse
 from pathlib import Path
 import logging
 from lightspeed_rag_content.asciidoc import AsciidoctorConverter
+from packaging.version import Version
 from typing import Generator, Tuple
 import xml.etree.ElementTree as ET
 
@@ -107,10 +108,15 @@ def red_hat_docs_path(
             docinfo_content = f.read()
             tree = ET.fromstring(f"<root>{docinfo_content}</root>")
 
-            if get_xml_element_text(tree, "productnumber") != docs_version:
+            productnumber = get_xml_element_text(tree, "productnumber")
+            if Version(productnumber) != Version(docs_version):
+                LOG.warning(
+                    f"{docinfo} productnumber {productnumber} != {docs_version}. Skipping ..."
+                )
                 continue
 
             if (path_title := get_xml_element_text(tree, "title")) is None:
+                LOG.warning(f"{docinfo} title is blanks Skipping ...")
                 continue
 
             path_title = path_title.lower().replace(" ", "_")


### PR DESCRIPTION
This correctly processes the existing titles, and adds the 6 other docs that are in the repo. Plaintext output is produced for each doc.

```
$ ./scripts/get_rhoso_plaintext_docs.sh
[...]
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Processing: /home/csibbitt/src/github.com/openstack-lightspeed/rag-content/rhoso_docs/titles/updating-your-environment/master.adoc
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Processing: /home/csibbitt/src/github.com/openstack-lightspeed/rag-content/rhoso_docs/titles/validating-and-troubleshooting-deployed-cloud/master.adoc
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Using asciidoctor with /usr/bin/asciidoctor path
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Processing: /home/csibbitt/src/github.com/openstack-lightspeed/rag-content/rhoso_docs/doc-Command_Line_Interface_Reference/master.adoc
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Using asciidoctor with /usr/bin/asciidoctor path
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Processing: /home/csibbitt/src/github.com/openstack-lightspeed/rag-content/rhoso_docs/doc-Configuration_Reference/master.adoc
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Using asciidoctor with /usr/bin/asciidoctor path
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Processing: /home/csibbitt/src/github.com/openstack-lightspeed/rag-content/rhoso_docs/doc-Deploying_Distributed_Compute_Nodes_with_Separate_Heat_Stacks/master.adoc
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Using asciidoctor with /usr/bin/asciidoctor path
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Processing: /home/csibbitt/src/github.com/openstack-lightspeed/rag-content/rhoso_docs/doc-Installing_Ember_CSI/master.adoc
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Using asciidoctor with /usr/bin/asciidoctor path
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Processing: /home/csibbitt/src/github.com/openstack-lightspeed/rag-content/rhoso_docs/doc-OpenStack_Benchmarking_Service/master.adoc
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Using asciidoctor with /usr/bin/asciidoctor path
INFO:lightspeed_rag_content.asciidoc.asciidoctor_converter:Processing: /home/csibbitt/src/github.com/openstack-lightspeed/rag-content/rhoso_docs/doc-Product_Guide/master.adoc

 $ ls -ltr rhoso-docs-plaintext/
 [...]
 drwxr-xr-x. 1 csibbitt csibbitt 20 Apr  3 13:09  updating_your_environment_to_the_latest_maintenance_release
drwxr-xr-x. 1 csibbitt csibbitt 20 Apr  3 13:09  validating_and_troubleshooting_the_deployed_cloud
drwxr-xr-x. 1 csibbitt csibbitt 20 Apr  3 13:09 'command_line_interface_(cli)_reference'
drwxr-xr-x. 1 csibbitt csibbitt 20 Apr  3 13:09  configuration_reference
drwxr-xr-x. 1 csibbitt csibbitt 20 Apr  3 13:09  deploying_distributed_compute_nodes_with_separate_heat_stacks
drwxr-xr-x. 1 csibbitt csibbitt 20 Apr  3 13:09  installing_ember-csi_on_openshift_container_platform
drwxr-xr-x. 1 csibbitt csibbitt 20 Apr  3 13:09  red_hat_openstack_platform_benchmarking_service
drwxr-xr-x. 1 csibbitt csibbitt 20 Apr  3 13:09  introduction_to_red_hat_openstack_platform
```