### PR TITLE
Use python3.11 on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ curl -O https://raw.githubusercontent.com/road-core/rag-content/refs/heads/main/
 6. Download the embedding model.
 
 ```
-python ./download_embeddings_model.py \
+python3.11 ./download_embeddings_model.py \
     -l ./embeddings_model/ \
     -r sentence-transformers/all-mpnet-base-v2
 ```
@@ -51,7 +51,7 @@ python ./download_embeddings_model.py \
 7. Generate the vector database.
 
 ```
-python ./scripts/generate_embeddings_openstack.py \
+python3.11 ./scripts/generate_embeddings_openstack.py \
         -o ./vector_db/ \
         -of openstack-docs-plaintext/ \
         -md embeddings_model \


### PR DESCRIPTION
The first command when we create the virtualenv explicitly points to python3.11. The following command only points to "python" which can lead to errors:

(.venv) [lucas@unicorn02 os-rag-content]$ python ./download_embeddings_model.py \
    -l ./embeddings_model/ \
    -r sentence-transformers/all-mpnet-base-v2
Traceback (most recent call last):
  File "/home/lucas/os-rag-content/./download_embeddings_model.py", line 8, in <module>
    from huggingface_hub import snapshot_download
ModuleNotFoundError: No module named 'huggingface_hub