### PR TITLE
Get embeddings from existing container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ OS_VERSION                     ?= 2024.2
 INDEX_NAME                     ?= os-docs-$(OS_VERSION)
 RHOSO_DOCS_GIT_URL             ?= ""
 RHOSO_DOCS_ATTRIBUTES_FILE_URL ?= ""
+OSLS_CONTAINER                 ?= quay.io/openstack-lightspeed/rag-content:latest
 
 # Define behavior based on the flavor
 ifeq ($(FLAVOR),cpu)
@@ -24,6 +25,12 @@ build-image-os: ## Build a openstack rag-content container image
 	--build-arg RHOSO_DOCS_GIT_URL=$(RHOSO_DOCS_GIT_URL) \
 	--build-arg RHOSO_DOCS_ATTRIBUTES_FILE_URL=$(RHOSO_DOCS_ATTRIBUTES_FILE_URL) \
 	--build-arg INDEX_NAME=$(INDEX_NAME) .
+
+get-embeddings:
+	podman create --replace --name tmp-rag-container $(OSLS_CONTAINER) true
+	rm -rf vector_db embeddings_model
+	podman cp tmp-rag-container:/rag/embeddings_model embeddings_model
+	podman rm tmp-rag-container
 
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'

--- a/README.md
+++ b/README.md
@@ -34,21 +34,13 @@ pip install -r requirements.txt
 ./scripts/get_openstack_plaintext_docs.sh
 ```
 
-5. Download `download_embeddings_model.py` from [road-core/rag-content](https://github.com/road-core/rag-content).
+5. Download the embedding model.
 
 ```
-curl -O https://raw.githubusercontent.com/road-core/rag-content/refs/heads/main/scripts/download_embeddings_model.py
+make get-embeddings
 ```
 
-6. Download the embedding model.
-
-```
-python ./download_embeddings_model.py \
-    -l ./embeddings_model/ \
-    -r sentence-transformers/all-mpnet-base-v2
-```
-
-7. Generate the vector database.
+6. Generate the vector database.
 
 ```
 python ./scripts/generate_embeddings_openstack.py \
@@ -60,7 +52,7 @@ python ./scripts/generate_embeddings_openstack.py \
         -w $(( $(nproc --all) / 2 ))
 ```
 
-8. Use the vector database stored in `./vector_db`.
+7. Use the vector database stored in `./vector_db`.
 
 
 ## Build Container Image Containing OpenStack Vector Database


### PR DESCRIPTION
Instead of having to download a script from road-core, then run it to download the embeddings model, we can just download it from an existing image in quay.

$ make get-embeddings
$ ls embeddings_model/
...