### PR TITLE
Add script argument to choose how to deal with unreachable URLS

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 ARG FLAVOR=cpu
-FROM ghcr.io/road-core/rag-content-${FLAVOR}:latest as road-core-rag-builder
+FROM ghcr.io/lightspeed-core/rag-content-${FLAVOR}:latest as lightspeed-core-rag-builder
 ARG OS_VERSION=2024.2
 ARG INDEX_NAME=os-docs-${OS_VERSION}
 ARG OS_PROJECTS
@@ -43,8 +43,8 @@ RUN if [ "$BUILD_UPSTREAM_DOCS" = "true" ]; then \
 
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-COPY --from=road-core-rag-builder /rag-content/vector_db /rag/vector_db/os_product_docs
-COPY --from=road-core-rag-builder /rag-content/embeddings_model /rag/embeddings_model
+COPY --from=lightspeed-core-rag-builder /rag-content/vector_db /rag/vector_db/os_product_docs
+COPY --from=lightspeed-core-rag-builder /rag-content/embeddings_model /rag/embeddings_model
 
 RUN mkdir /licenses
 COPY LICENSE /licenses/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lightspeed-rag-content @ git+https://github.com/road-core/rag-content@main
+lightspeed-rag-content @ git+https://github.com/ligthspeed-core/rag-content@main
 packaging

--- a/scripts/generate_embeddings_openstack.py
+++ b/scripts/generate_embeddings_openstack.py
@@ -67,6 +67,14 @@ if __name__ == "__main__":
         required=False,
         help="Directory containing the plain text RHOSO documentation",
     )
+    parser.add_argument(
+        "-ua",
+        "--unreachable-action",
+        choices=["warn", "drop", "fail"],
+        default="warn",
+        required=False,
+        help="What to do when encountering a doc whose URL can't be reached",
+    )
     args = parser.parse_args()
 
     if not args.folder and not args.rhoso_folder:
@@ -96,6 +104,7 @@ if __name__ == "__main__":
             required_exts=[
                 ".txt",
             ],
+            unreachable_action=args.unreachable_action,
         )
 
     # Process the RHOSO documents, if provided
@@ -106,6 +115,7 @@ if __name__ == "__main__":
             required_exts=[
                 ".txt",
             ],
+            unreachable_action=args.unreachable_action,
         )
 
     # Save to the output directory


### PR DESCRIPTION
Depends-on: https://github.com/lightspeed-core/rag-content/pull/2

Tests will fail until that merges. Error is `TypeError: DocumentProcessor.process() got an unexpected keyword argument 'unreachable_action'`