### PR TITLE
Include api-ref documentation of the OpenStack projects

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,6 +17,7 @@ COPY ./scripts ./scripts
 # python-devel and pcre-devel are needed for python-openstackclient
 RUN dnf install -y graphviz python-devel pcre-devel
 RUN pip install tox
+RUN pip install html2text
 
 RUN if [ "$BUILD_UPSTREAM_DOCS" = "true" ]; then \
         ./scripts/get_openstack_plaintext_docs.sh; \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lightspeed-rag-content @ git+https://github.com/road-core/rag-content@main
 packaging
+html2text


### PR DESCRIPTION
Api-ref for most projects is placed in the main repo of the project but in the `api-ref` folder. It is slightly different for Neutron as api-ref is placed in neutron-lib repo. Bacause of that reason neutron-lib is also added to the list of the projects for which documentation (and now api-ref) is build by default.

Additionally this patch adds also small hack to convert api-ref from the html to text format. It has to be done with html2text tool as os-api-ref project currently don't support generating api-ref documentation directly in the "text" format. It should be possible once [1] will be merged and released.

[1] https://review.opendev.org/c/openstack/os-api-ref/+/951410