### PR TITLE
[OSPRH-16305] Set the image tag equal to the index name

### DIFF
--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -20,6 +20,7 @@ on:
 
 env:
   IMAGE_NAME: quay.io/openstack-lightspeed/${{ github.event.repository.name }}
+  OS_VERSION: 2024.2
 
 jobs:
   build-and-push-rag-content:
@@ -46,9 +47,15 @@ jobs:
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2
+        env:
+          # This variable should be used to specify the tag for the vector DB
+          # container image and the name of the index ID for the data inside
+          # that image. The idea is to make the image tag equal to the index ID
+          # used inside, so it's easy to understand what index ID is within that image.
+          INDEX_NAME: os-docs-${{ env.OS_VERSION }}
         with:
           image: ${{ github.event.repository.name }}
-          tags: latest ${{ github.sha }}
+          tags: ${{ github.sha }} ${{ env.INDEX_NAME }}
           oci: true
           # We are using FLAVOR=cpu because Github runners do not offer GPUs and
           # NUM_WORKERS is set to 4 because that's the default number of cores
@@ -57,6 +64,8 @@ jobs:
             FLAVOR=cpu
             NUM_WORKERS=4
             OS_PROJECTS=${{ env.OS_PROJECTS }}
+            OS_VERSION=${{ env.OS_VERSION }}
+            INDEX_NAME=${{ env.INDEX_NAME }}
           context: .
           containerfiles: |
             ./Containerfile

--- a/Containerfile
+++ b/Containerfile
@@ -49,6 +49,9 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=lightspeed-core-rag-builder /rag-content/vector_db /rag/vector_db/os_product_docs
 COPY --from=lightspeed-core-rag-builder /rag-content/embeddings_model /rag/embeddings_model
 
+ARG INDEX_NAME
+ENV INDEX_NAME=${INDEX_NAME}
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(error Unsupported FLAVOR $(FLAVOR), must be 'cpu' or 'gpu')
 endif
 
 build-image-os: ## Build a openstack rag-content container image
-	podman build -t rag-content-openstack:latest -f ./Containerfile \
+	podman build -t rag-content-openstack:$(INDEX_NAME) -f ./Containerfile \
 	--build-arg FLAVOR=$(TORCH_GROUP) \
 	--build-arg NUM_WORKERS=$(NUM_WORKERS) \
 	--build-arg OS_PROJECTS=$(OS_PROJECTS) \


### PR DESCRIPTION
This change makes it easier to identify the index ID used within the vector database image by tagging the image with the index ID itself. This simplifies consumption of the vector database image, as the tag clearly indicates which index ID should be used when consuming data from it.

This commit also updates the tags used in our GitHub Actions pipeline. Now, two tags will be assigned to the image:

 * Git SHA: Identifies the specific commit.
 * os-docs-${OS_VERSION}: Specifies the index ID for the data stored within the vector database image.