### PR TITLE
Several fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ pip install -r requirements.txt
 ./scripts/get_openstack_plaintext_docs.sh
 ```
 
+   Useful env vars for this script:
+   - `NUM_WORKERS` if the default number (`nproc`) is too high
+   - `WORKING_DIR` if you don't want to use the default `/tmp/os_docs_temp`.
+
 5. Download the embedding model.
 
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ pip install -r requirements.txt
 ```
 
    Useful env vars for this script:
+   - `CLEAN_FILES` what to clean on success: `venv`, `all` (whole project), or nothing (default).
    - `NUM_WORKERS` if the default number (`nproc`) is too high
    - `WORKING_DIR` if you don't want to use the default `/tmp/os_docs_temp`.
 

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -64,7 +64,7 @@ fi
 IFS=' ' read -r -a os_projects <<< "$OS_PROJECTS"
 
 # Working directory
-WORKING_DIR="/tmp/os_docs_temp"
+WORKING_DIR="${WORKING_DIR:-/tmp/os_docs_temp}"
 
 # The current directory where the script was invoked
 CURR_DIR=$(pwd)

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -16,9 +16,17 @@
 
 set -eou pipefail
 
+PYTHON_VERSION=${PYTHON_VERSION:-3.11}
+PYTHON="python${PYTHON_VERSION}"
+
 # Check if 'tox' is available
 if ! command -v tox &> /dev/null; then
   echo "Error: 'tox' is not installed, please install it before continuing." >&2
+  exit 1
+fi
+
+if ! command -v "$PYTHON"  &> /dev/null; then
+  echo "Error: '$PYTHON' is not installed, please install it before continuing." >&2
   exit 1
 fi
 
@@ -101,6 +109,7 @@ generate_text_doc() {
 [testenv:text-docs]
 description =
     Build documentation in text format.
+basepython = $PYTHON
 commands =
   sphinx-build --keep-going -j auto -b text doc/source doc/build/text
 deps =
@@ -114,6 +123,7 @@ deps =
 [testenv:text-api-ref]
 description =
     Build documentation in text format.
+basepython = $PYTHON
 commands =
   sphinx-build --keep-going -j auto -b html -d api-ref/build/doctrees api-ref/source api-ref/build/html
 deps =
@@ -232,8 +242,8 @@ deps =
     cd -
 }
 
-mkdir -p $WORKING_DIR
-cd $WORKING_DIR
+mkdir -p "$WORKING_DIR"
+cd "$WORKING_DIR"
 echo "Working directory: $WORKING_DIR"
 
 for os_project in "${os_projects[@]}"; do


### PR DESCRIPTION
* Fix get docs when python3.11 is not the default python version on the system
* Support cleaning venv and project on get docs script
* Allow setting WORKING_DIR for get docs so we can use a non `tmpfs` directory
