### PR TITLE
Fail on unreachable links

### DIFF
--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -66,6 +66,7 @@ jobs:
             OS_PROJECTS=${{ env.OS_PROJECTS }}
             OS_VERSION=${{ env.OS_VERSION }}
             INDEX_NAME=${{ env.INDEX_NAME }}
+            DOCS_LINK_UNREACHABLE_ACTION=fail
           context: .
           containerfiles: |
             ./Containerfile

--- a/Containerfile
+++ b/Containerfile
@@ -33,6 +33,7 @@ COPY --from=docs-base /rag-content/openstack-docs-plaintext /rag-content/opensta
 COPY --from=docs-base /rag-content/scripts /rag-content/scripts
 
 ARG BUILD_UPSTREAM_DOCS=true
+ARG DOCS_LINK_UNREACHABLE_ACTION=warn
 ARG OS_VERSION=2024.2
 ARG INDEX_NAME=os-docs-${OS_VERSION}
 ARG NUM_WORKERS=1
@@ -55,6 +56,7 @@ RUN if [ "$BUILD_UPSTREAM_DOCS" = "true" ]; then \
     --model-name ${EMBEDDING_MODEL} \
     --index ${INDEX_NAME} \
     --workers ${NUM_WORKERS} \
+    --unreachable-action ${DOCS_LINK_UNREACHABLE_ACTION} \
     ${FOLDER_ARG}
 
 # -- Stage 3: Store the vector DB into ubi-minimal image ----------------------


### PR DESCRIPTION
This commit ensures that the CI fails when the vector DB built inside the job contains unreachable links. This should prevent any future patches from breaking the building of the URLs.