### PR TITLE
Update repo to llama-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ There are several ways how to access the OpenStack vector database:
 
 ## Generate OpenStack Vector Database
 
-1. Install requirements: `python3.11.*`.
+1. Install requirements: `python3.12.*`.
 
 2. Create virtualenv.
 
 ```
-python3.11 -m venv .venv && . .venv/bin/activate
+python3.12 -m venv .venv && . .venv/bin/activate
 ```
 
 3. Install dependencies.
@@ -59,6 +59,8 @@ make get-embeddings-model
 
 6. Generate the vector database.
 
+- For llama-index
+
 ```
 python ./scripts/generate_embeddings_openstack.py \
         -o ./vector_db/ \
@@ -69,7 +71,27 @@ python ./scripts/generate_embeddings_openstack.py \
         -w $(( $(nproc --all) / 2 ))
 ```
 
-7. Use the vector database stored in `./vector_db`.
+- For llama-stack
+
+```
+python ./scripts/generate_embeddings_openstack.py \
+        -o ./vector_db/ \
+        -f openstack-docs-plaintext/ \
+        -md embeddings_model \
+        -mn sentence-transformers/all-mpnet-base-v2 \
+        -i os-docs \
+        --vector-store-type=llamastack-faiss \
+        -w $(( $(nproc --all) / 2 ))
+```
+
+7. Test the database stored in `./vector_db`
+
+```bash
+curl -o /tmp/query_rag.py https://raw.githubusercontent.com/lightspeed-core/rag-content/refs/heads/main/scripts/query_rag.py
+python /tmp/query_rag.py -p vector_db -x os-docs -m embeddings_model -k 5 -q "how can I configure a cinder backend"
+```
+
+8. Use the vector database stored in `./vector_db`.
 
 
 ## Build Container Image Containing OpenStack Vector Database

--- a/scripts/generate_embeddings_openstack.py
+++ b/scripts/generate_embeddings_openstack.py
@@ -103,6 +103,7 @@ if __name__ == "__main__":
         args.workers,
         args.vector_store_type,
         args.index.replace("-", "_"),
+        manual_chunking=args.manual_chunking,
     )
 
     # Process the OpenStack documents, if provided

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -16,7 +16,7 @@
 
 set -eou pipefail
 
-PYTHON_VERSION=${PYTHON_VERSION:-3.11}
+PYTHON_VERSION=${PYTHON_VERSION:-3.12}
 PYTHON="python${PYTHON_VERSION}"
 
 # Check if 'tox' is available

--- a/scripts/rhoso_adoc_docs_to_text.py
+++ b/scripts/rhoso_adoc_docs_to_text.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.11
+#!/usr/bin/python3.12
 # Copyright 2025 Red Hat, Inc.
 # All Rights Reserved.
 #


### PR DESCRIPTION
This patch updates the repository to support llama-stack vector databases.

We need to use python 3.12 and wait until lightspeed rag-content PR 28 [[1]] merges.

[1]: https://github.com/lightspeed-core/rag-content/pull/28