### PR TITLE
Fix container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,22 @@ ARG BUILD_UPSTREAM_DOCS=true
 ARG NUM_WORKERS=1
 ARG OS_PROJECTS
 ARG OS_VERSION=2024.2
+ARG PRUNE_PATHS=""
 ARG RHOSO_CA_CERT_URL=""
+ARG RHOSO_DOCS_GIT_URL=""
+ARG RHOSO_DOCS_ATTRIBUTES_FILE_URL=""
+ARG RHOSO_RELNOTES_GIT_URL=""
+ARG RHOSO_RELNOTES_GIT_BRANCH=""
+
+ENV NUM_WORKERS=$NUM_WORKERS
+ENV OS_PROJECTS=$OS_PROJECTS
+ENV OS_VERSION=$OS_VERSION
+ENV PRUNE_PATHS=$PRUNE_PATHS
+ENV RHOSO_CA_CERT_URL=$RHOSO_CA_CERT_URL
+ENV RHOSO_DOCS_GIT_URL=$RHOSO_DOCS_GIT_URL
+ENV RHOSO_DOCS_ATTRIBUTES_FILE_URL=$RHOSO_DOCS_ATTRIBUTES_FILE_URL
+ENV RHOSO_RELNOTES_GIT_URL=$RHOSO_RELNOTES_GIT_URL
+ENV RHOSO_RELNOTES_GIT_BRANCH=$RHOSO_RELNOTES_GIT_BRANCH
 
 USER 0
 WORKDIR /rag-content
@@ -32,19 +47,21 @@ FROM ghcr.io/lightspeed-core/rag-content-${FLAVOR}:latest as lightspeed-core-rag
 COPY --from=docs-base /rag-content/openstack-docs-plaintext /rag-content/openstack-docs-plaintext
 COPY --from=docs-base /rag-content/scripts /rag-content/scripts
 
+ARG FLAVOR=cpu
 ARG BUILD_UPSTREAM_DOCS=true
 ARG DOCS_LINK_UNREACHABLE_ACTION=warn
 ARG OS_VERSION=2024.2
 ARG INDEX_NAME=os-docs-${OS_VERSION}
 ARG NUM_WORKERS=1
 ARG RHOSO_DOCS_GIT_URL=""
-ARG RHOSO_DOCS_ATTRIBUTES_FILE_URL=""
-ARG RHOSO_RELNOTES_GIT_BRANCH=""
-ARG RHOSO_RELNOTES_GIT_URL=""
+
 
 WORKDIR /rag-content
 
-RUN if [ "$BUILD_UPSTREAM_DOCS" = "true" ]; then \
+RUN if [ "$FLAVOR" = "gpu" ]; then \
+        python -c "import torch; exit(0) if torch.cuda.is_available() else exit(1)"; \
+    fi && \
+    if [ "$BUILD_UPSTREAM_DOCS" = "true" ]; then \
         FOLDER_ARG="--folder openstack-docs-plaintext"; \
     fi && \
     if [ ! -z "${RHOSO_DOCS_GIT_URL}" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 FLAVOR                         ?= cpu
 NUM_WORKERS                    ?= $$(( $(shell nproc --all) / 2))
 OS_VERSION                     ?= 2024.2
+# Check scripts/get_openstack_plaintext_docs.sh to see OS_PROJECTS defaults
+OS_PROJECTS                    ?=
+PRUNE_PATHS                    ?= ""
 INDEX_NAME                     ?= os-docs-$(OS_VERSION)
 RHOSO_DOCS_GIT_URL             ?= ""
 RHOSO_DOCS_ATTRIBUTES_FILE_URL ?= ""
@@ -9,6 +12,8 @@ RHOSO_RELNOTES_GIT_URL         ?= ""
 RHOSO_RELNOTES_GIT_BRANCH      ?= ""
 RHOSO_CA_CERT_URL              ?= ""
 OSLS_CONTAINER                 ?= quay.io/openstack-lightspeed/rag-content:latest
+BUILD_UPSTREAM_DOCS            ?= true
+DOCS_LINK_UNREACHABLE_ACTION   ?= warn
 
 # Define behavior based on the flavor
 ifeq ($(FLAVOR),cpu)
@@ -25,11 +30,14 @@ build-image-os: ## Build a openstack rag-content container image
 	--build-arg NUM_WORKERS=$(NUM_WORKERS) \
 	--build-arg OS_PROJECTS=$(OS_PROJECTS) \
 	--build-arg OS_VERSION=$(OS_VERSION) \
+	--build-arg PRUNE_PATHS=$(PRUNE_PATHS) \
 	--build-arg RHOSO_DOCS_GIT_URL=$(RHOSO_DOCS_GIT_URL) \
 	--build-arg RHOSO_DOCS_ATTRIBUTES_FILE_URL=$(RHOSO_DOCS_ATTRIBUTES_FILE_URL) \
 	--build-arg RHOSO_RELNOTES_GIT_URL=$(RHOSO_RELNOTES_GIT_URL) \
 	--build-arg RHOSO_RELNOTES_GIT_BRANCH=$(RHOSO_RELNOTES_GIT_BRANCH) \
 	--build-arg RHOSO_CA_CERT_URL=$(RHOSO_CA_CERT_URL) \
+	--build-arg BUILD_UPSTREAM_DOCS=$(BUILD_UPSTREAM_DOCS) \
+	--build-arg DOCS_LINK_UNREACHABLE_ACTION=$(DOCS_LINK_UNREACHABLE_ACTION) \
 	--build-arg INDEX_NAME=$(INDEX_NAME) .
 
 get-embeddings-model: ## Download embeddings model from the openstack-lightspeed/rag-content container image

--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ python ./scripts/generate_embeddings_openstack.py \
 make build-image-os FLAVOR=cpu
 ```
 
+If we have an Nvidia GPU card properly configured in podman we can run:
+
+```bash
+make build-image-os FLAVOR=gpu
+```
+
+If our GPU is not an Nvidia card and is supported by podman and torch, then we
+can override the default value in `BUILD_GPU_ARGS` (here we show de default
+value):
+
+```bash
+make build-image-os FLAVOR=gpu BUILD_GPU_ARGS="--device nvidia.com/gpu=all"
+```
+
 3. The generated vector database can be found under `/rag/vector_db/os_product_docs`
 inside of the image.
 

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -43,7 +43,9 @@ _OS_PROJECTS="nova horizon keystone neutron cinder manila glance swift ceilomete
 octavia designate heat placement ironic barbican aodh watcher adjutant blazar \
 cyborg magnum mistral skyline-apiserver skyline-console storlets \
 venus vitrage zun python-openstackclient tempest trove zaqar masakari"
-OS_PROJECTS=${OS_PROJECTS:-$_OS_PROJECTS}
+if [ -z "$OS_PROJECTS" ]; then
+    OS_PROJECTS=$_OS_PROJECTS
+fi
 
 # List of paths to prune from final docs set. The default set are pages that
 # are no longer published but are still generated from the git source


### PR DESCRIPTION
This PR fixes our container image process that was broken in several ways:

- Some arguments are used before being declared (eg: RHOSO_DOCS_GIT_URL)
- Some arguments are not being passed in the make target (eg: BUILD_UPSTREAM_DOCS)
- Some arguments are not defined in the make target (eg: OS_PROJECTS and DOCS_LINK_UNREACHABLE_ACTION)
- The Containerfile is assuming that `ARG` parameters become environmental variables and will therefore be available to script, but that's not the case (eg: OS_PROJECTS or OS_VERSION for get_openstack_plaintext_docs.sh)

It cannot fix the GPU one because it's broken due to the base image [[1]](https://issues.redhat.com/browse/LCORE-438), but for GPU the container image build process will fail if we try to use the `FLAVOR=gpu` but the GPU is not really available in the container when doing the build. It also makes sure to pass the right parameters to `podman build` so it can use the GPUs.