### PR TITLE
Fix downstream container building

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,13 +1,36 @@
 ARG FLAVOR=cpu
 
-# -- Stage 1: Generate plaintext formatted documentation ----------------------
-FROM registry.access.redhat.com/ubi9/python-311 as docs-base
+# -- Stage 1a: Generate upstream plaintext formatted documentation ------------
+FROM registry.access.redhat.com/ubi9/python-311 as docs-base-upstream
 
 ARG BUILD_UPSTREAM_DOCS=true
 ARG NUM_WORKERS=1
 ARG OS_PROJECTS
 ARG OS_VERSION=2024.2
 ARG PRUNE_PATHS=""
+
+ENV NUM_WORKERS=$NUM_WORKERS
+ENV OS_PROJECTS=$OS_PROJECTS
+ENV OS_VERSION=$OS_VERSION
+ENV PRUNE_PATHS=$PRUNE_PATHS
+
+USER 0
+WORKDIR /rag-content
+
+COPY ./scripts ./scripts
+
+# Graphviz is needed to generate text documentation for octavia
+# python-devel and pcre-devel are needed for python-openstackclient
+RUN if [ "$BUILD_UPSTREAM_DOCS" = "true" ]; then \
+        dnf install -y graphviz python-devel pcre-devel pip && \
+        pip install tox && \
+        ./scripts/get_openstack_plaintext_docs.sh; \
+    fi
+
+# -- Stage 1b: Generate downstream plaintext formatted documentation ----------
+FROM ghcr.io/lightspeed-core/rag-content-${FLAVOR}:latest as docs-base-downstream
+
+ARG NUM_WORKERS=1
 ARG RHOSO_CA_CERT_URL=""
 ARG RHOSO_DOCS_GIT_URL=""
 ARG RHOSO_DOCS_ATTRIBUTES_FILE_URL=""
@@ -15,9 +38,6 @@ ARG RHOSO_RELNOTES_GIT_URL=""
 ARG RHOSO_RELNOTES_GIT_BRANCH=""
 
 ENV NUM_WORKERS=$NUM_WORKERS
-ENV OS_PROJECTS=$OS_PROJECTS
-ENV OS_VERSION=$OS_VERSION
-ENV PRUNE_PATHS=$PRUNE_PATHS
 ENV RHOSO_CA_CERT_URL=$RHOSO_CA_CERT_URL
 ENV RHOSO_DOCS_GIT_URL=$RHOSO_DOCS_GIT_URL
 ENV RHOSO_DOCS_ATTRIBUTES_FILE_URL=$RHOSO_DOCS_ATTRIBUTES_FILE_URL
@@ -31,21 +51,16 @@ COPY ./scripts ./scripts
 
 # Graphviz is needed to generate text documentation for octavia
 # python-devel and pcre-devel are needed for python-openstackclient
-RUN dnf install -y graphviz python-devel pcre-devel
-RUN pip install tox
-
-RUN if [ "$BUILD_UPSTREAM_DOCS" = "true" ]; then \
-        ./scripts/get_openstack_plaintext_docs.sh; \
-    fi
-
+#   python-devel was already installed in our base image
 RUN if [ ! -z "${RHOSO_DOCS_GIT_URL}" ]; then \
+        microdnf install -y graphviz pcre-devel && \
         ./scripts/get_rhoso_plaintext_docs.sh; \
     fi
 
 # -- Stage 2: Compute embeddings for the doc chunks ---------------------------
 FROM ghcr.io/lightspeed-core/rag-content-${FLAVOR}:latest as lightspeed-core-rag-builder
-COPY --from=docs-base /rag-content/openstack-docs-plaintext /rag-content/openstack-docs-plaintext
-COPY --from=docs-base /rag-content/scripts /rag-content/scripts
+COPY --from=docs-base-upstream /rag-content /rag-content
+COPY --from=docs-base-downstream /rag-content /rag-content
 
 ARG FLAVOR=cpu
 ARG BUILD_UPSTREAM_DOCS=true

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -15,6 +15,7 @@
 # under the License.
 
 set -eou pipefail
+set -x
 
 PYTHON_VERSION=${PYTHON_VERSION:-3.12}
 PYTHON="python${PYTHON_VERSION}"

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -125,7 +125,7 @@ deps =
     echo "Generating the plain-text documentation for OpenStack $project"
     # Clone the project's repository, if not present
     if [ ! -d "$project" ]; then
-        git clone https://opendev.org/openstack/"$project".git
+        git clone -v --depth=1 --single-branch -b "stable/${_os_version}" https://opendev.org/openstack/"$project".git
     fi
 
     cd "$project"

--- a/scripts/get_rhoso_plaintext_docs.sh
+++ b/scripts/get_rhoso_plaintext_docs.sh
@@ -48,11 +48,11 @@ fi
 # Configure git and curl commands with CA certificate if available
 if [ -f "${CA_CERT_FILE}" ]; then
     echo "Git and curl will use CA certificate from ${RHOSO_CA_CERT_URL}"
-    git_clone() { git -c http.sslCAInfo="${CA_CERT_FILE}" clone "$@"; }
+    git_clone() { git -c http.sslCAInfo="${CA_CERT_FILE}" clone -v --depth=1 --single-branch "$@"; }
     curl_download() { curl -L --cacert "${CA_CERT_FILE}" "$@"; }
 else
     echo "Warning: No CA certificate provided, skipping certificate validation"
-    git_clone() { GIT_SSL_NO_VERIFY=true git clone "$@"; }
+    git_clone() { GIT_SSL_NO_VERIFY=true git clone -v --depth=1 --single-branch "$@"; }
     curl_download() { curl -L -k "$@"; }
 fi
 
@@ -79,7 +79,7 @@ generate_relnotes_rhoso() {
     local rhoso_relnotes_folder="./rhoso_relnotes"
 
     if [ ! -d "${rhoso_relnotes_folder}" ]; then
-        git_clone --single-branch -b "${RHOSO_RELNOTES_GIT_BRANCH}" "${RHOSO_RELNOTES_GIT_URL}" "${rhoso_relnotes_folder}"
+        git_clone -b "${RHOSO_RELNOTES_GIT_BRANCH}" "${RHOSO_RELNOTES_GIT_URL}" "${rhoso_relnotes_folder}"
     fi
 
     python ./scripts/rhoso_adoc_docs_to_text.py \

--- a/scripts/get_rhoso_plaintext_docs.sh
+++ b/scripts/get_rhoso_plaintext_docs.sh
@@ -15,6 +15,7 @@
 # under the License.
 
 set -eou pipefail
+set -x
 
 # URL of Git repository storing RHOSO documentation
 RHOSO_DOCS_GIT_URL=${RHOSO_DOCS_GIT_URL:-}


### PR DESCRIPTION
In a previous PR we fixed the upstream container building process,
but downstream was still broken.

This patch fixes the downstream build process by separating the upstream
and downstream processes of building the plain text documentation.

This approach is easier than choosing a base image and then install all
the missing dependencies.

If this is deemed to be inefficient we can always join them at a later
time.