### PR TITLE
Set default value for `branch_prefix`

### DIFF
--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -124,7 +124,9 @@ deps =
 "
 
     echo "Generating the plain-text documentation for OpenStack $project"
+
     # Clone the project's repository, if not present
+    local branch_prefix=""
     if [ "$_os_version" != "master" ]; then
         branch_prefix="stable/"
     fi


### PR DESCRIPTION
Set default value for branch_prefix to ensure that the generation of the documentation does not fail for Tempest due to undefined branch_prefix var:

```
./scripts/get_openstack_plaintext_docs.sh: line 133: branch_prefix: unbound variable
```

Closes: #50