### PR TITLE
Make sure `OS_PROJECTS` is set to default value

### DIFF
--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -44,7 +44,7 @@ _OS_PROJECTS="nova horizon keystone neutron cinder manila glance swift ceilomete
 octavia designate heat placement ironic barbican aodh watcher adjutant blazar \
 cyborg magnum mistral skyline-apiserver skyline-console storlets \
 venus vitrage zun python-openstackclient tempest trove zaqar masakari"
-OS_PROJECTS=${OS_PROJECTS:-$_OS_PROJECTS}
+OS_PROJECTS=${OS_PROJECTS-$_OS_PROJECTS}
 
 # List of paths to prune from final docs set. The default set are pages that
 # are no longer published but are still generated from the git source


### PR DESCRIPTION
The OS_PROJECTS variable is accessed when it is not set. If it is not set through ENV variable running the get_openstack_plaintext.sh script outside of the container can fail:

./scripts/get_openstack_plaintext_docs.sh: line 47: OS_PROJECTS: unbound variable

This commit makes sure that OS_PROJECTS is set even when it is not passed through the ENV variable. This enables running of the script outside of the Container.