### PR TITLE
Add support for OKP data ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,7 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# OKP guardrails
+okp-content/*
+mimir-*

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ BUILD_UPSTREAM_DOCS            ?= true
 DOCS_LINK_UNREACHABLE_ACTION   ?= warn
 BUILD_EXTRA_ARGS               ?=
 VECTOR_DB_TYPE                 ?= faiss
+BUILD_OKP_CONTENT              ?= false
+OKP_CONTENT                    ?= "all"
 
 # Define behavior based on the flavor
 ifeq ($(FLAVOR),cpu)
@@ -47,6 +49,8 @@ build-image-os: ## Build a openstack rag-content container image
 	--build-arg DOCS_LINK_UNREACHABLE_ACTION=$(DOCS_LINK_UNREACHABLE_ACTION) \
 	--build-arg INDEX_NAME=$(INDEX_NAME) \
 	--build-arg VECTOR_DB_TYPE=$(VECTOR_DB_TYPE) \
+	--build-arg BUILD_OKP_CONTENT=$(BUILD_OKP_CONTENT) \
+	--build-arg OKP_CONTENT=$(OKP_CONTENT) \
 	$(BUILD_GPU_ARGS) .
 
 get-embeddings-model: ## Download embeddings model from the openstack-lightspeed/rag-content container image

--- a/README.md
+++ b/README.md
@@ -129,6 +129,29 @@ inside of the image.
 podman run localhost/rag-content-openstack:latest ls /rag/vector_db/os_product_docs
 ```
 
+## Build with OKP content
+
+To include OKP content in the RAG, copy the non-paywalled OKP content into
+the `okp-content` directory of this project, for example:
+
+```bash
+cp -r red_hat_content/{documentation,errata,pages} okp-content/
+```
+
+Next, set `BUILD_OKP_CONTENT` to true when building the container image,
+for example:
+
+```bash
+make build-image-os BUILD_OKP_CONTENT="true"
+```
+
+By default, all content in the folder will be ingested. To choose specific
+items to include in the RAG, use the `OKP_CONTENT` parameter with a
+space-separated list of content, for example:
+
+```bash
+make build-image-os BUILD_OKP_CONTENT="true" OKP_CONTENT="pages documentation"
+```
 
 ## Download the Pre-built Container Image Containing OpenStack Vector Database
 

--- a/okp-content/README
+++ b/okp-content/README
@@ -1,0 +1,4 @@
+Placeholder for the OKP content: This folder is reserved for all
+OKP-related files and currently serves as a placeholder until the actual
+content is added. Check the README for instructions on how to include
+the OKP content in the image.

--- a/scripts/generate_embeddings_openstack.py
+++ b/scripts/generate_embeddings_openstack.py
@@ -2,6 +2,8 @@
 
 """Utility script to generate embeddings."""
 
+import shutil
+import tempfile
 import logging
 import os
 import re
@@ -9,12 +11,16 @@ from pathlib import Path
 import sys
 
 from lightspeed_rag_content import utils
+from lightspeed_rag_content import okp
 from lightspeed_rag_content.metadata_processor import MetadataProcessor
 from lightspeed_rag_content.document_processor import DocumentProcessor
+from llama_index.readers.file.markdown.base import MarkdownReader
 
 logging.basicConfig(
     level=logging.WARNING, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
+
+OKP_CONTENT_TYPES = ["erratas", "docs", "pages"]
 
 
 def clean_url(unclean_url):
@@ -44,7 +50,7 @@ class OpenstackDocsMetadataProcessor(MetadataProcessor):
 class RedHatDocsMetadataProcessor(MetadataProcessor):
     ROOT_URL = "https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/{}/html-single"
 
-    def __init__(self, docs_path, base_url=ROOT_URL, version="18.0"):
+    def __init__(self, docs_path, version, base_url=ROOT_URL):
         super(RedHatDocsMetadataProcessor, self).__init__()
         self._base_path = os.path.abspath(docs_path)
         if self._base_path.endswith("/"):
@@ -75,6 +81,83 @@ class RedHatDocsMetadataProcessor(MetadataProcessor):
             )
 
 
+#
+# Functions related to OpenStack OKP
+#
+
+
+def copy_openstack_errata(input_dir: Path, output_dir: Path) -> Path:
+    """Returns a directory containing only OpenStack related errata files."""
+    errata_dir = input_dir / "errata"
+    if not errata_dir.exists():
+        raise ValueError(
+            f"The specified errata directory '{errata_dir}' does not exist."
+        )
+
+    print("Copying OpenStack related errata files...")
+    os.makedirs(output_dir / "errata", exist_ok=True)
+    for f in okp.yield_files_related_to_projects(errata_dir, projects=["openstack"]):
+        # Copy the file to the output directory
+        shutil.copy2(f, output_dir / "errata")
+    print("OpenStack related errata files copied successfully.")
+
+
+def _yield_openstack_pages_md_files(base_dir):
+    """Yield OpenStack related Markdown files from the given directory."""
+    for root, _, files in os.walk(base_dir):
+        for file in files:
+            if "openstack" in file.lower() and file.lower().endswith(".md"):
+                yield os.path.join(root, file)
+
+
+def copy_openstack_pages(input_dir: Path, output_dir: Path) -> Path:
+    """Returns a directory containing only OpenStack related pages."""
+    pages_dir = input_dir / "pages"
+    if not pages_dir.exists():
+        raise ValueError(f"The specified pages directory '{pages_dir}' does not exist.")
+
+    print("Copying OpenStack related pages...")
+    os.makedirs(output_dir / "pages", exist_ok=True)
+    for f in _yield_openstack_pages_md_files(pages_dir):
+        # Copy the file to the output directory
+        shutil.copy2(f, output_dir / "pages")
+    print("OpenStack related pages copied successfully.")
+
+
+def _yield_openstack_documentation_md_files(base_dir):
+    """Yield OpenStack related documentation Markdown files from the given directory."""
+    for root, dirs, files in os.walk(base_dir):
+        # Only search if the current folder's name is exactly "single-page"
+        if os.path.basename(root) == "single-page":
+            for file in files:
+                if file.lower().endswith(".md"):
+                    yield os.path.join(root, file)
+
+
+def copy_openstack_documentation(
+    input_dir: Path, output_dir: Path, version: str
+) -> Path:
+    """Returns a directory containing only OpenStack related documentation files."""
+    docs_dir = (
+        input_dir / f"documentation/red_hat_openstack_services_on_openshift/{version}"
+    )
+    if not docs_dir.exists():
+        raise ValueError(
+            f"The specified documentation directory '{docs_dir}' does not exist."
+        )
+
+    print("Copying OpenStack documentation files...")
+    os.makedirs(output_dir / "docs", exist_ok=True)
+    for f in _yield_openstack_documentation_md_files(docs_dir):
+        # Copy the file to the output directory
+        shutil.copy2(f, output_dir / "docs")
+    print("OpenStack documentation files copied successfully.")
+
+
+#
+# End functions related to OKP
+#
+
 if __name__ == "__main__":
     parser = utils.get_common_arg_parser()
     parser.add_argument(
@@ -92,11 +175,36 @@ if __name__ == "__main__":
         required=False,
         help="What to do when encountering a doc whose URL can't be reached",
     )
+    parser.add_argument(
+        "-osv",
+        "--openstack-version",
+        type=str,
+        required=False,
+        default="18.0",
+        help="Version of the OpenStack documentation to process",
+    )
+    parser.add_argument(
+        "-of",
+        "--okp-folder",
+        type=Path,
+        required=False,
+        help="Directory containing the OKP files",
+    )
+    parser.add_argument(
+        "-oc",
+        "--okp-content",
+        nargs="+",
+        choices=OKP_CONTENT_TYPES + ["all"],
+        default=["all"],
+        required=False,
+        help="Choose one or more OKP content types, or 'all' for all of them",
+    )
+
     args = parser.parse_args()
 
-    if not args.folder and not args.rhoso_folder:
+    if not any([args.folder, args.rhoso_folder, args.okp_folder]):
         print(
-            'Error: Either the "--folder" and/or "--rhoso-folder" options '
+            'Error: Either the "--folder" and/or "--rhoso-folder" and/or "--okp-folder" options '
             "must be provided",
             file=sys.stderr,
         )
@@ -129,12 +237,58 @@ if __name__ == "__main__":
     if args.rhoso_folder:
         document_processor.process(
             str(args.rhoso_folder),
-            metadata=RedHatDocsMetadataProcessor(args.rhoso_folder),
+            metadata=RedHatDocsMetadataProcessor(
+                args.rhoso_folder, args.openstack_version
+            ),
             required_exts=[
                 ".txt",
             ],
             unreachable_action=args.unreachable_action,
         )
 
+    # Process the OKP files, if provided
+    okp_out_dir = None
+    if args.okp_folder:
+        if not args.okp_folder.exists():
+            raise ValueError(
+                f"The specified OKP folder '{args.okp_folder}' does not exist."
+            )
+
+        print(f"Processing OKP files from: {args.okp_folder}")
+
+        if "all" in args.okp_content:
+            args.okp_content = OKP_CONTENT_TYPES
+
+        # Create a temporary directory for OKP files
+        okp_out_dir = Path(tempfile.mkdtemp(prefix="okp_openstack_"))
+
+        for content_type in args.okp_content:
+            if content_type == "erratas":
+                copy_openstack_errata(args.okp_folder, okp_out_dir)
+            elif content_type == "docs":
+                copy_openstack_documentation(
+                    args.okp_folder, okp_out_dir, version=args.openstack_version
+                )
+            elif content_type == "pages":
+                copy_openstack_pages(args.okp_folder, okp_out_dir)
+
+        print(
+            f"Processing OpenStack related {', '.join(args.okp_content)} files in {okp_out_dir}"
+        )
+        document_processor.process(
+            str(okp_out_dir),
+            metadata=okp.OKPMetadataProcessor(),
+            required_exts=[
+                ".md",
+            ],
+            file_extractor={".md": MarkdownReader()},
+            unreachable_action=args.unreachable_action,
+        )
+
     # Save to the output directory
     document_processor.save(args.index, str(args.output))
+
+    # Clean up the OKP output directory if it exists
+    if okp_out_dir and okp_out_dir.exists():
+        print(f"Cleaning up temporary OKP output directory: {okp_out_dir}")
+        shutil.rmtree(okp_out_dir)


### PR DESCRIPTION
This ONLY INGEST PUBLIC DATA, all paywalled data (from /solutions and
/articles) ARE IGNORED!
The data consumed are erratas/cves (cves are part of erratas), pages and
RHOSO documentation.

New parameters were added:
  --okp-folder: Directory containing the OKP files.
  --openstack-version: Version of the OpenStack documentation to process
  --okp-content: Choose one or more OKP content types, or 'all' for all of them

For the --okp-content, the user can specify which content to build, for
example:

* Only erratas
scripts/generate_embeddings_openstack.py --okp-folder /okp --okp-content
erratas

* Erratas and docs
scripts/generate_embeddings_openstack.py --okp-folder /okp --okp-content
erratas docs --openstack-version 18.0

* All (erratas, docs and pages)
scripts/generate_embeddings_openstack.py --okp-folder /okp --okp-content
all --openstack-version 18.0