### PR TITLE
Use rag-content-cpu for downstream docs cloning

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -56,9 +56,9 @@ COPY ./scripts ./scripts
 # Copy the OKP content to inside the container
 COPY ./okp-content ./okp-content
 
-# Graphviz is needed to generate text documentation for octavia
-# python-devel and pcre-devel are needed for python-openstackclient
-#   python-devel was already installed in our base image
+# * Graphviz is needed to generate text documentation for octavia
+# * python-devel and pcre-devel are needed for python-openstackclient
+# * python-devel was already installed in our base image
 RUN if [ ! -z "${RHOSO_DOCS_GIT_URL}" ]; then \
         microdnf install -y graphviz pcre-devel && \
         ./scripts/get_rhoso_plaintext_docs.sh; \

--- a/Containerfile
+++ b/Containerfile
@@ -28,7 +28,9 @@ RUN if [ "$BUILD_UPSTREAM_DOCS" = "true" ]; then \
     fi
 
 # -- Stage 1b: Generate downstream plaintext formatted documentation ----------
-FROM ghcr.io/lightspeed-core/rag-content-${FLAVOR}:latest as docs-base-downstream
+# We explicitly use the CPU flavored lightspeed-core/rag-content image here
+# since there is no computation done in this stage that relies on GPU.
+FROM ghcr.io/lightspeed-core/rag-content-cpu:latest as docs-base-downstream
 
 ARG NUM_WORKERS=1
 ARG RHOSO_CA_CERT_URL=""


### PR DESCRIPTION
If one tries to build the downstream rag-content image with a GPU, they encounter the following error:

```
microdnf: command not found
```

This is caused by a different base image for the rag-content-gpu image, which uses dnf instead of microdnf.

This commit fixes this issue by ensuring that we use a CPU based image for the downstream documentation generation, since no GPU computation happens in that stage.