### PR TITLE
[Testing][OSPRH-19820] Do not use commit tag for periodic builds

### DIFF
--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -21,6 +21,7 @@ on:
 env:
   IMAGE_NAME: quay.io/openstack-lightspeed/${{ github.event.repository.name }}
   OS_VERSION: 2024.2
+  TAGS: latest
 
 jobs:
   build-and-push-rag-content:
@@ -44,18 +45,35 @@ jobs:
         run: |
           echo OS_PROJECTS="nova" >> $GITHUB_ENV
 
+      # The INDEX_NAME variable specifies both the container image tag for the
+      # vector DB and the index ID for the data stored within the image. By making
+      # the image tag match the internal index ID, it becomes easy to identify
+      # which index is contained within each image.
+      - name: Set INDEX_NAME env variable
+        run: |
+          echo "INDEX_NAME=os-docs-${{ env.OS_VERSION }}" >> $GITHUB_ENV
+
+      # For periodic nightly builds, use nightly-YYYYMMDD and os-docs-2024.2
+      # tags to avoid overwriting commit-based tags. This prevents breaking
+      # existing sha256 references used by openstack-k8s-operators/openstack-operator
+      # builds. Please modify with caution!
+      - name: Set TAGS for periodic builds
+        if: github.event_name == 'schedule'
+        run: |
+          echo "TAGS=nightly-$(date -u +'%Y%m%d') ${{ env.INDEX_NAME }}" >> $GITHUB_ENV
+
+      - name: Set TAGS for push builds
+        if: github.event_name == 'push'
+        run: |
+          echo "TAGS=${{ github.sha }} ${{ env.INDEX_NAME }}" >> $GITHUB_ENV
+
       - name: Build image
         id: build_image
         uses: redhat-actions/buildah-build@v2
         env:
-          # This variable should be used to specify the tag for the vector DB
-          # container image and the name of the index ID for the data inside
-          # that image. The idea is to make the image tag equal to the index ID
-          # used inside, so it's easy to understand what index ID is within that image.
-          INDEX_NAME: os-docs-${{ env.OS_VERSION }}
         with:
           image: ${{ github.event.repository.name }}
-          tags: ${{ github.sha }} ${{ env.INDEX_NAME }}
+          tags: ${{ env.TAGS }}
           oci: true
           # We are using FLAVOR=cpu because Github runners do not offer GPUs and
           # NUM_WORKERS is set to 4 because that's the default number of cores


### PR DESCRIPTION
The openstack-k8s-operators/openstack-operator references the openstack-lightspeed/rag-content image. During the build process of the openstack-operator, the os-docs-2024.2 tag gets transferred to a sha256 value (the openstack-operator build references the image through that sha256 value).

Until now, this repository was overwriting both the image with the commit-tag and the os-docs-2024.2 tag in the periodic build, which removed the image with the sha256 value that was referenced in the earlier openstack-operator build.

This commit fixes this issue by using nightly-YYYYMMDD tags for the periodic builds to ensure that existing tags do not get overwritten and the referenced images with sha256 values do not disappear.