### PR TITLE
Set unreachable_action to "warn" for Extra Folder

### DIFF
--- a/scripts/generate_embeddings_openstack.py
+++ b/scripts/generate_embeddings_openstack.py
@@ -397,11 +397,15 @@ if __name__ == "__main__":
                 file=sys.stderr,
             )
             sys.exit(1)
+        # NOTE(lucas): unreachable_action for extra_docs is marked as
+        # "warn" always because extra_docs are meant for SME and personal
+        # notes/documents. Having it to "fail" will cause the build to
+        # fail since most of these documents do not have any valid link.
         document_processor.process(
             str(extra),
             metadata=ExtraDocsMetadataProcessor(extra),
             required_exts=[".md", ".txt"],
-            unreachable_action=args.unreachable_action,
+            unreachable_action="warn",
             ignore_list=ignore_list,
         )
 


### PR DESCRIPTION
The extra folder is meant for SME notes, personal documentation, etc... These documents do not always have valid links (most often than not they do not have it) so having setting the unreachable_action to "fail" would always cause the build to error out due.

This patch changes it an always set the unreachable_action to "warn" for the Extra Folder (aka Extra Docs). That way the build can proceed when these are included and unreachable_action=fail for the rest of the more curated documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build failures caused by unreachable links in supplementary documentation. Unreachable links in extra documentation now generate warnings instead of causing build failures, while other documentation sources maintain their original handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->