### PR TITLE
Fix placement docs build by pinning setuptools<70

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ make build-image-os BUILD_OCP_DOCS=true FLAVOR=gpu
 ```
 
 If our GPU is not an Nvidia card and is supported by podman and torch, then we
-can override the default value in `BUILD_GPU_ARGS` (here we show de default
+can override the default value in `BUILD_GPU_ARGS` (here we show the default
 value):
 
 ```bash

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -152,6 +152,13 @@ generate_text_doc() {
 "
     elif [ "$project" == "python-openstackclient" ]; then
         install_cmd="pip install {opts} {packages}"
+    elif [ "$project" == "cinder" ]; then
+        deps_prefix="  setuptools<82
+  cryptography<47
+"
+    elif [ "$project" == "placement" ]; then
+        deps_prefix="  setuptools<82
+"
     fi
 
     local tox_text_docs_target="
@@ -217,10 +224,12 @@ deps =
     # TODO(mtembo): The following are temporary workarounds until upstream fixes are available.
     #    * cinder/placement/horizon = sphinxcontrib-actdiag uses pkg_resources removed in setuptools 70+
     #                                 Pin setuptools<82 to maintain compatibility (OSPRH-27424)
+    #                                 These are now handled via deps_prefix above (lines 147-162)
     #                                 Remove when sphinxcontrib-actdiag is updated upstream
     #
     #    * cinder = Also requires cryptography<47 because cursive library references SECT571K1
     #               binary elliptic curves removed in cryptography 47.0.0 (CVE-2026-26007)
+    #               This is now handled via deps_prefix above (lines 153-156)
     #               Remove when cursive is updated to handle cryptography 47+
     #
     if [ "$project" == "designate" ]; then
@@ -231,11 +240,6 @@ deps =
         rm -rf doc/source/template_guide/
     elif [[ "$project" == "trove" || "$project" == "zaqar" ]]; then
         tox_text_docs_target+="  -r{toxinidir}/requirements.txt"
-    elif [ "$project" == "cinder" ]; then
-        tox_text_docs_target+="  setuptools<82
-  cryptography<47"
-    elif [ "$project" == "placement" ]; then
-        tox_text_docs_target+="  setuptools<82"
     fi
 
     if grep -q "text-docs" tox.ini; then

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -189,9 +189,9 @@ deps =
     #                    generate the docs
     #
     # TODO(mtembo): The following are temporary workarounds until upstream fixes are available.
-    #    * cinder/placement = sphinxcontrib-actdiag uses pkg_resources removed in setuptools 70+
-    #                         Pin setuptools<82 to maintain compatibility (OSPRH-27424)
-    #                         Remove when sphinxcontrib-actdiag is updated upstream
+    #    * cinder/placement/horizon = sphinxcontrib-actdiag uses pkg_resources removed in setuptools 70+
+    #                                 Pin setuptools<82 to maintain compatibility (OSPRH-27424)
+    #                                 Remove when sphinxcontrib-actdiag is updated upstream
     #
     #    * cinder = Also requires cryptography<47 because cursive library references SECT571K1
     #               binary elliptic curves removed in cryptography 47.0.0 (CVE-2026-26007)
@@ -209,6 +209,8 @@ deps =
         tox_text_docs_target+="  setuptools<82
   cryptography<47"
     elif [ "$project" == "placement" ]; then
+        tox_text_docs_target+="  setuptools<82"
+    elif [ "$project" == "horizon" ]; then
         tox_text_docs_target+="  setuptools<82"
     fi
 

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -129,18 +129,16 @@ generate_text_doc() {
     # This prevents cryptography from being upgraded during package dependency install.
     # Remove when upstream deps (cursive, sphinxcontrib-actdiag) are compatible with latest versions.
 
-    # TODO(mtembo): TEMPORARY WORKAROUND - Horizon needs setuptools<82 in install_command
-    # (not just deps) because XStatic packages fail during pip wheel building phase
-    # before deps are processed. Remove when horizon/XStatic packages are compatible
-    # with setuptools 70+ or when switching to OpenStack stable/2026.1
-    #
-    # Original (restore this when workaround no longer needed):
-    # local install_cmd="pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
-    #
-    # Workaround (pre-install setuptools<82 for horizon):
-    local install_cmd="pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
+    # TODO(mtembo): TEMPORARY WORKAROUND - Horizon needs setuptools<82 before deps install
+    # because XStatic packages fail during pip wheel building when pkg_resources is missing.
+    # Using commands_pre to install setuptools before deps processing begins.
+    # Remove when horizon/XStatic packages are compatible with setuptools 70+ or when
+    # switching to OpenStack stable/2026.1
+    local commands_pre=""
     if [ "$project" == "horizon" ]; then
-        install_cmd="pip install 'setuptools<82' && pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
+        commands_pre="commands_pre =
+  pip install 'setuptools<82'
+"
     fi
 
     local tox_text_docs_target="
@@ -149,8 +147,8 @@ generate_text_doc() {
 description =
     Build documentation in text format.
 basepython = $PYTHON
-install_command = $install_cmd
-commands =
+install_command = pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}
+${commands_pre}commands =
   sphinx-build --keep-going -j auto -b text doc/source doc/build/text
 deps =
   -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version}

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -134,12 +134,15 @@ generate_text_doc() {
     # instead of our pinned setuptools<82. Without --no-build-isolation, pip creates a fresh
     # environment for building XStatic packages, and our setuptools<82 constraint is ignored.
     # With --no-build-isolation, pip uses the main environment where setuptools<82 is installed.
+    # Additionally, horizon's install_command must NOT use constraint file to avoid conflict between
+    # dev version (0.0.0) and constraints file version (25.5.2). Dependencies still get constraints
+    # via the deps list below.
     # Remove when horizon/XStatic packages are compatible with setuptools 70+
     local install_cmd="pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
     local deps_prefix=""
 
     if [ "$project" == "horizon" ]; then
-        install_cmd="pip install --no-build-isolation -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
+        install_cmd="pip install --no-build-isolation {opts} {packages}"
         deps_prefix="  setuptools<82
 "
     fi

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -129,15 +129,14 @@ generate_text_doc() {
     # This prevents cryptography from being upgraded during package dependency install.
     # Remove when upstream deps (cursive, sphinxcontrib-actdiag) are compatible with latest versions.
 
-    # TODO(mtembo): TEMPORARY WORKAROUND - Horizon needs setuptools<82 before deps install
+    # TODO(mtembo): TEMPORARY WORKAROUND - Horizon needs setuptools<82 as FIRST dep
     # because XStatic packages fail during pip wheel building when pkg_resources is missing.
-    # Using commands_pre to install setuptools before deps processing begins.
+    # setuptools must be installed BEFORE -r{toxinidir}/doc/requirements.txt is processed.
     # Remove when horizon/XStatic packages are compatible with setuptools 70+ or when
     # switching to OpenStack stable/2026.1
-    local commands_pre=""
+    local deps_prefix=""
     if [ "$project" == "horizon" ]; then
-        commands_pre="commands_pre =
-  pip install 'setuptools<82'
+        deps_prefix="  setuptools<82
 "
     fi
 
@@ -148,10 +147,10 @@ description =
     Build documentation in text format.
 basepython = $PYTHON
 install_command = pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}
-${commands_pre}commands =
+commands =
   sphinx-build --keep-going -j auto -b text doc/source doc/build/text
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version}
+${deps_prefix}  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version}
   -r{toxinidir}/doc/requirements.txt
 "
 
@@ -222,8 +221,6 @@ deps =
         tox_text_docs_target+="  setuptools<82
   cryptography<47"
     elif [ "$project" == "placement" ]; then
-        tox_text_docs_target+="  setuptools<82"
-    elif [ "$project" == "horizon" ]; then
         tox_text_docs_target+="  setuptools<82"
     fi
 

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -125,12 +125,16 @@ log_and_die() {
 generate_text_doc() {
     local project=$1
     local _os_version=$2
+    # TODO(mtembo): install_command enforces constraints for ALL pip install phases.
+    # This prevents cryptography from being upgraded during package dependency install.
+    # Remove when upstream deps (cursive, sphinxcontrib-actdiag) are compatible with latest versions.
     local tox_text_docs_target="
 
 [testenv:text-docs]
 description =
     Build documentation in text format.
 basepython = $PYTHON
+install_command = pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}
 commands =
   sphinx-build --keep-going -j auto -b text doc/source doc/build/text
 deps =
@@ -139,10 +143,12 @@ deps =
 "
 
     # API-Ref tox target definition (only used if OS_API_DOCS=true)
+    # TODO(mtembo): Same install_command workaround as text-docs env above.
     local tox_text_api_ref_target="
 [testenv:text-api-ref]
 description =
     Build API reference documentation in HTML format.
+install_command = pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}
 commands =
   sphinx-build --keep-going -j auto -b html -d api-ref/build/doctrees api-ref/source api-ref/build/html
 deps =
@@ -182,6 +188,15 @@ deps =
     #    * trove/zaqar = The doc/requirements.txt file does not install all deps required to
     #                    generate the docs
     #
+    # TODO(mtembo): The following are temporary workarounds until upstream fixes are available.
+    #    * cinder/placement = sphinxcontrib-actdiag uses pkg_resources removed in setuptools 70+
+    #                         Pin setuptools<82 to maintain compatibility (OSPRH-27424)
+    #                         Remove when sphinxcontrib-actdiag is updated upstream
+    #
+    #    * cinder = Also requires cryptography<47 because cursive library references SECT571K1
+    #               binary elliptic curves removed in cryptography 47.0.0 (CVE-2026-26007)
+    #               Remove when cursive is updated to handle cryptography 47+
+    #
     if [ "$project" == "designate" ]; then
         sed -i "/'ext\.support_matrix',/d" "doc/source/conf.py"
     elif [ "$project" == "ironic" ]; then
@@ -190,6 +205,11 @@ deps =
         rm -rf doc/source/template_guide/
     elif [[ "$project" == "trove" || "$project" == "zaqar" ]]; then
         tox_text_docs_target+="  -r{toxinidir}/requirements.txt"
+    elif [ "$project" == "cinder" ]; then
+        tox_text_docs_target+="  setuptools<82
+  cryptography<47"
+    elif [ "$project" == "placement" ]; then
+        tox_text_docs_target+="  setuptools<82"
     fi
 
     if grep -q "text-docs" tox.ini; then

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -128,13 +128,28 @@ generate_text_doc() {
     # TODO(mtembo): install_command enforces constraints for ALL pip install phases.
     # This prevents cryptography from being upgraded during package dependency install.
     # Remove when upstream deps (cursive, sphinxcontrib-actdiag) are compatible with latest versions.
+
+    # TODO(mtembo): TEMPORARY WORKAROUND - Horizon needs setuptools<82 in install_command
+    # (not just deps) because XStatic packages fail during pip wheel building phase
+    # before deps are processed. Remove when horizon/XStatic packages are compatible
+    # with setuptools 70+ or when switching to OpenStack stable/2026.1
+    #
+    # Original (restore this when workaround no longer needed):
+    # local install_cmd="pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
+    #
+    # Workaround (pre-install setuptools<82 for horizon):
+    local install_cmd="pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
+    if [ "$project" == "horizon" ]; then
+        install_cmd="pip install 'setuptools<82' && pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
+    fi
+
     local tox_text_docs_target="
 
 [testenv:text-docs]
 description =
     Build documentation in text format.
 basepython = $PYTHON
-install_command = pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}
+install_command = $install_cmd
 commands =
   sphinx-build --keep-going -j auto -b text doc/source doc/build/text
 deps =

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -129,22 +129,29 @@ generate_text_doc() {
     # This prevents cryptography from being upgraded during package dependency install.
     # Remove when upstream deps (cursive, sphinxcontrib-actdiag) are compatible with latest versions.
 
-    # TODO(mtembo): TEMPORARY WORKAROUND - Horizon needs --no-build-isolation
-    # because XStatic packages create isolated build environments that get latest setuptools (70+)
-    # instead of our pinned setuptools<82. Without --no-build-isolation, pip creates a fresh
-    # environment for building XStatic packages, and our setuptools<82 constraint is ignored.
+    # TODO(mtembo): TEMPORARY WORKAROUND for projects with version conflicts
+    # Some projects (horizon, python-openstackclient) have constraint conflicts when
+    # building from git: dev version (0.0.0) vs constraints file specific version.
+    # Solution: Remove constraints from install_command for these projects only.
+    # Dependencies still get constraints via the deps list.
+    #
+    # Horizon additionally needs --no-build-isolation because XStatic packages create
+    # isolated build environments that get latest setuptools (70+) instead of our pinned
+    # setuptools<82. Without --no-build-isolation, pip creates a fresh environment for
+    # building XStatic packages, and our setuptools<82 constraint is ignored.
     # With --no-build-isolation, pip uses the main environment where setuptools<82 is installed.
-    # Additionally, horizon's install_command must NOT use constraint file to avoid conflict between
-    # dev version (0.0.0) and constraints file version (25.5.2). Dependencies still get constraints
-    # via the deps list below.
     # Remove when horizon/XStatic packages are compatible with setuptools 70+
     local install_cmd="pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
     local deps_prefix=""
 
+    # Projects that need constraints removed from install_command to avoid
+    # version conflicts between dev version (0.0.0) and constraints file version
     if [ "$project" == "horizon" ]; then
         install_cmd="pip install --no-build-isolation {opts} {packages}"
         deps_prefix="  setuptools<82
 "
+    elif [ "$project" == "python-openstackclient" ]; then
+        install_cmd="pip install {opts} {packages}"
     fi
 
     local tox_text_docs_target="

--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -129,13 +129,17 @@ generate_text_doc() {
     # This prevents cryptography from being upgraded during package dependency install.
     # Remove when upstream deps (cursive, sphinxcontrib-actdiag) are compatible with latest versions.
 
-    # TODO(mtembo): TEMPORARY WORKAROUND - Horizon needs setuptools<82 as FIRST dep
-    # because XStatic packages fail during pip wheel building when pkg_resources is missing.
-    # setuptools must be installed BEFORE -r{toxinidir}/doc/requirements.txt is processed.
-    # Remove when horizon/XStatic packages are compatible with setuptools 70+ or when
-    # switching to OpenStack stable/2026.1
+    # TODO(mtembo): TEMPORARY WORKAROUND - Horizon needs --no-build-isolation
+    # because XStatic packages create isolated build environments that get latest setuptools (70+)
+    # instead of our pinned setuptools<82. Without --no-build-isolation, pip creates a fresh
+    # environment for building XStatic packages, and our setuptools<82 constraint is ignored.
+    # With --no-build-isolation, pip uses the main environment where setuptools<82 is installed.
+    # Remove when horizon/XStatic packages are compatible with setuptools 70+
+    local install_cmd="pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
     local deps_prefix=""
+
     if [ "$project" == "horizon" ]; then
+        install_cmd="pip install --no-build-isolation -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}"
         deps_prefix="  setuptools<82
 "
     fi
@@ -146,7 +150,7 @@ generate_text_doc() {
 description =
     Build documentation in text format.
 basepython = $PYTHON
-install_command = pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version} {opts} {packages}
+install_command = $install_cmd
 commands =
   sphinx-build --keep-going -j auto -b text doc/source doc/build/text
 deps =


### PR DESCRIPTION
Placement documentation build fails because sphinxcontrib-actdiag extension still uses pkg_resources which was removed in setuptools 70+

This adds a temporary workaround using OpenStack's standard TOX_CONSTRAINTS_FILE pattern to pin setuptools<70 until upstream are fixed officially.

Related: [OSPRH-27424](https://redhat.atlassian.net/browse/OSPRH-27424)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Documentation build now injects explicit dependency constraints during generation to ensure consistent, repeatable builds.
  * Temporary compatibility pins/workarounds added for specific project docs to address known dependency issues during doc builds; conditional pins applied for subsequent runs.

* **Documentation**
  * Fixed wording in GPU build instructions to correct a typographical error and clarify how to override build arguments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openstack-lightspeed/rag-content/pull/104)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->