### PR TITLE
CI: Prune trove 2025.2 testing.txt file

### DIFF
--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -73,6 +73,8 @@ if [ "${PRUNE_PATHS:-}" == "" ]; then
         cinder/2025.2_docs/contributor/api/cinder.api.v2.volume_metadata.txt
         cinder/2025.2_docs/contributor/api/cinder.api.v2.volumes.txt
         cinder/2025.2_docs/contributor/api/cinder.api.v2.views.volumes.txt
+        # Trove 2025.2 redirects to latest, and this file is no longer present there.
+        trove/2025.2_docs/contributor/testing.txt
     )
 fi
 


### PR DESCRIPTION
This change adds the trove/2025.2_docs/contributor/testing.txt link to the prune list. Trove redirects the /2025.2 docs to /latest [0] and in latest that file no longer exists causing the CI to fail because of unreacheable links.

[0] https://docs.openstack.org/trove/2025.2/contributor/testing.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated the documentation build script's pruning configuration to exclude outdated documentation paths that are no longer available in current releases. This maintenance change ensures the build process correctly handles documentation structure changes and prevents inclusion of deprecated paths in the final output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openstack-lightspeed/rag-content/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->