### PR TITLE
Add OKP embeddings model to RAG image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -166,6 +166,9 @@ RUN if [ "$BUILD_OCP_DOCS" = "true" ] && [ -d "/rag-content/rag-docs/ocp-product
         mkdir -p /rag-content/ocp_vector_db; \
     fi
 
+# Download the OKP embeddings model
+RUN python ./scripts/download_okp_embeddings.py --output-dir okp_embeddings_model
+
 # Clean up the OKP content
 RUN rm -rf ./okp-content
 
@@ -173,6 +176,7 @@ RUN rm -rf ./okp-content
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=lightspeed-core-rag-builder /rag-content/vector_db /rag/vector_db/os_product_docs
 COPY --from=lightspeed-core-rag-builder /rag-content/embeddings_model /rag/embeddings_model
+COPY --from=lightspeed-core-rag-builder /rag-content/okp_embeddings_model /rag/okp_embeddings_model
 COPY --from=lightspeed-core-rag-builder /rag-content/ocp_vector_db /rag/ocp_vector_db
 
 ARG INDEX_NAME

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ defusedxml==0.7.1
 packaging==26.2
 lxml==6.1.1
 html2text==2025.4.15
+huggingface_hub==1.19.0

--- a/scripts/download_okp_embeddings.py
+++ b/scripts/download_okp_embeddings.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Download the OKP embeddings model from Hugging Face."""
+
+import argparse
+import sys
+
+from huggingface_hub import snapshot_download
+
+MODEL_ID = "ibm-granite/granite-embedding-30m-english"
+DEFAULT_OUTPUT_DIR = "okp_embeddings_model"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download the OKP embeddings model from Hugging Face."
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory to save the model (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    args = parser.parse_args()
+
+    print(f"Downloading model {MODEL_ID} to {args.output_dir}")
+    try:
+        snapshot_download(repo_id=MODEL_ID, local_dir=args.output_dir)
+    except Exception as e:
+        print(f"Failed to download model {MODEL_ID}: {e}", file=sys.stderr)
+        sys.exit(1)
+    print("Download complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
OKP does uses the ibm-granite/granite-embedding-30m-english embeddings model but it does not ship it. In our current OKP deployment setup, Llama-Stack (OGX) is downloading it directly from Hugging Face but this is a problem for an offline deployment of OpenStack Lightspeed.

This change adds a download script that fetches the ibm-granite/granite-embedding-30m-english model from Hugging Face and the Containerfile is updated to run it during build and include the model at /rag/okp_embeddings_model in the final image.

This will later be used to configure Llama-Stack + OKP so it does not have to download it as part of the deployment anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated the runtime environment to include a downloaded OKP embeddings model.

* **Chores**
  * Improved the container image build flow with additional model download and removal of unneeded content for a smaller, cleaner runtime image.
  * Added a helper script and new dependency to support downloading the model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->