### PR TITLE
Build OGX compatible RAG image

### DIFF
--- a/.github/workflows/build-and-push-rag-content.yaml
+++ b/.github/workflows/build-and-push-rag-content.yaml
@@ -56,7 +56,7 @@ jobs:
       # which index is contained within each image.
       - name: Set INDEX_NAME env variable
         run: |
-          echo "INDEX_NAME=os-docs-${{ env.OS_VERSION }}" >> $GITHUB_ENV
+          echo "INDEX_NAME=os-docs-${{ env.OS_VERSION }}-ogx" >> $GITHUB_ENV
 
       # For periodic nightly builds, use nightly-YYYYMMDD and os-docs-2025.2
       # tags to avoid overwriting commit-based tags. This prevents breaking
@@ -92,6 +92,7 @@ jobs:
             DOCS_LINK_UNREACHABLE_ACTION=fail
             OS_API_DOCS=${{ env.OS_API_DOCS }}
             BUILD_OCP_DOCS=false
+            VECTOR_DB_TYPE=llamastack-faiss
           context: .
           containerfiles: |
             ./Containerfile


### PR DESCRIPTION
Since the team's pivoted from using OLS in favor of LCORE, our RAG image built in this GH workflow is no longer compatible with that.

This PR changes the build-and-push-rag-content.yaml workflow to generate a OGX compatible image.

The new image will have -ogx appended to the tag and index name. So the previous operator (the one based on OLS) can continue to point to existing tags without breaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build process with new vector database configuration
  * Modified deployment workflow index naming convention during build execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->